### PR TITLE
Replace depricated Mojo::Transaction::success

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+?.?    ????-??-??
+    - Use non-deprecated replacement for Mojo::Transaction::success
 0.6    2014-06-08
     - Updated for recent tx error hash change.
     - Fixed bug tracker url.

--- a/lib/Mojolicious/Plugin/Proxy.pm
+++ b/lib/Mojolicious/Plugin/Proxy.pm
@@ -35,7 +35,8 @@ sub register {
 
 sub _proxy_tx {
   my ($self, $tx) = @_;
-  if (my $res = $tx->success) {
+  if (!$tx->error) {
+    my $res = $tx->res;
     $self->tx->res($res);
     $self->rendered;
   }


### PR DESCRIPTION
Recent Mojolicious has depricated Mojo::Transaction::success.  When using this plugin, I got the following warnings:

```
Mojo::Transaction::success is DEPRECATED in favor of
Mojo::Transaction::result and Mojo::Transaction::error at
/home/jmaslak/perl5/perlbrew/perls/perl-5.26.1/lib/site_perl/5.26.1/Mojolicious/Plugin/Proxy.pm
line 38.
```

This PR eliminates these deprecation warnings.