### PR TITLE
add test and fix for connection lost case

### DIFF
--- a/example/map.pl
+++ b/example/map.pl
@@ -1,0 +1,51 @@
+use Mojolicious::Lite -signatures;
+
+# This example is based on leaflet's tutorial (quick start guide)
+# https://leafletjs.com/examples/quick-start/
+#
+# The only change here is that requests to the openstreetmap API that we are
+# using are proxied through our backend, instead of been just sent by
+# the browser (client) to openstreetmap.com
+#
+# Reasons to do this vary from allowing users without full internet access
+# to use our app, or add authorization tokens in the backend
+# instead of just pasting it into front-end code, where the risk for that
+# token to be exposed is much bigger
+#
+plugin 'proxy';
+
+get '/' => 'index';
+
+get '/maps/:s/:z/:x/:y' => sub($c) {
+  my ($s, $z, $x, $y) = @{$c->stash}{qw/s z x y/};
+  $c->proxy_to("https://$s.tile.osm.org/$z/$x/$y.png", with_query_params => 1);
+};
+
+app->start;
+
+__DATA__
+
+@@ index.html.ep
+<!DOCKTYPE html>
+<html>
+    <head>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"
+   integrity="sha512-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC5CXdbqCmblAshOMAS6/keqq/sMZMZ19scR4PsZChSR7A=="
+   crossorigin=""/>
+<script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"
+   integrity="sha512-XQoYMqMTK8LvdxXYG3nZ448hOEQiglfqkJs1NOQV44cWnUrBc8PkAOcXy20w0vlaXaVUearIOBhiXZ5V3ynxwA=="
+   crossorigin=""></script>
+    </head>
+    <body>
+    <div id="mapid"></div>
+    <style>
+    #mapid { height: 180px; }
+    </style>
+    <script>
+var mymap = L.map('mapid').setView([51.505, -0.09], 13);
+L.tileLayer('/maps/{s}/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(mymap);
+    </script>
+    </body>
+</html>

--- a/lib/Mojolicious/Plugin/Proxy.pm
+++ b/lib/Mojolicious/Plugin/Proxy.pm
@@ -7,7 +7,6 @@ our $VERSION = '0.7';
 sub register {
   my ($self, $app) = @_;
 
-
   $app->helper(
     proxy_to => sub {
       my $c    = shift;
@@ -35,9 +34,10 @@ sub register {
 
 sub _proxy_tx {
   my ($self, $tx) = @_;
+  return unless (my $mtx = $self->tx);
   if (!$tx->error) {
     my $res = $tx->res;
-    $self->tx->res($res);
+    $mtx->res($res);
     $self->rendered;
   }
   else {

--- a/t/basic.t
+++ b/t/basic.t
@@ -1,7 +1,8 @@
 use Test::More;
 use Mojolicious::Lite;
 use Test::Mojo;
-use Test::More tests => 7;
+use Test::More tests => 11;
+BEGIN { $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll' }
 
 plugin 'proxy';
 
@@ -9,6 +10,11 @@ get '/foo' => sub { shift->render(text => 'bar'); } => 'foo';
 get '/bar' => sub { my $self=shift;$self->proxy_to($self->url_for('foo')->to_abs) };
 get '/baz' => sub { die "ARGH" } => 'baz';
 get '/fob' => sub { my $self=shift;$self->proxy_to($self->url_for('baz')->to_abs) };
+get '/qux' => sub {
+  my $self = shift;
+  $self->proxy_to($self->url_for('foo')->to_abs);
+  $self->render(text => 'quux');    # this will abort former proxy request
+};
 
 my $t=Test::Mojo->new;
 
@@ -17,3 +23,16 @@ $t->get_ok('/fob')
   ->status_is(500)
   ->content_is(qq/Failed to fetch data from backend/)
   ->header_is('X-Remote-Status','500: Internal Server Error');
+
+# Check for error in callback
+Mojo::IOLoop->singleton->reactor->unsubscribe('error');
+my $err;
+Mojo::IOLoop->singleton->reactor->once(
+  error => sub { $err .= pop; Mojo::IOLoop->stop });
+
+# no more than .1 secs
+Mojo::IOLoop->timer(.1 => sub { Mojo::IOLoop->stop });
+
+$t->get_ok('/qux')->status_is(200)->content_is('quux');
+Mojo::IOLoop->start;
+is $err, undef, 'no errors in reactor';


### PR DESCRIPTION
We are using this plugin to proxy requests to a map API from the browser to the backend (great plugin BTW!).

Sometimes, especially when the user zooms quickly in and out over the map, we see that the original requests from javascript are abandoned, and we get a lot of log lines with the following error:

```
I/O watcher failed: Can't call method "res" on an undefined value at /Users/daniel/perl5/perlbrew/perls/perl-5.30.2/lib/site_perl/5.30.2/Mojolicious/Plugin/Proxy.pm line 40.
```

I was able to fix it with a minor change, just asking if the controler's transaction was still active before actually passing the just arrived data from the proxy connection.

Please  take a look on the PR, it includes a test (that will fail with the current plugin implementation), the fix, and and example that you may find useful to include in the distribution.

BR,